### PR TITLE
Fix clown.talk response for i2c scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.0.2] (2016-11-24)
+Fixed bugs:
+- Fix clown.talk response for i2c scan
+
 ## [1.0.1] (2016-11-23)
 Fixed bugs:
 - Fix Segmentation fault in bc_talk

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
 project(bc-bridge LANGUAGES C)
-set(PROJECT_VERSION 1.0.0)
+set(PROJECT_VERSION 1.0.2)
 
 set(CMAKE_BUILD_TYPE Debug)
 #set(CMAKE_VERBOSE_MAKEFILE on)

--- a/src/bc_talk.h
+++ b/src/bc_talk.h
@@ -10,7 +10,7 @@
 #define BC_TALK_I2C_ADDRESS  0x81
 #define BC_TALK_UART_ADDRESS 0x82
 
-#define BC_TALK_DEVICE_NAME_SIZE 16
+#define BC_TALK_DEVICE_NAME_SIZE 21
 
 typedef enum
 {

--- a/src/task_i2c.c
+++ b/src/task_i2c.c
@@ -17,7 +17,7 @@ void *task_i2c_worker(void *task_parameter)
     task_i2c_action_t *action;
 
     char slaves[1024] = "";
-    char address_text[3];
+    char address_text[45];
     char topic[32];
     bool add_comma;
     uint8_t address;


### PR DESCRIPTION
Bad size variables.
On 64 bit arch work fine, but on 32 bit I get strange response.